### PR TITLE
Fix require path

### DIFF
--- a/lib/jikan/query.rb
+++ b/lib/jikan/query.rb
@@ -1,5 +1,5 @@
 require 'require_all'
-require_all 'lib/jikan/models'
+require_rel 'models'
 require 'jikan/api'
 
 module Jikan
@@ -42,7 +42,7 @@ module Jikan
       elsif flag == :stats
         Jikan::Stat.new(@json)
       end
-      
+
     end
 
     def manga_id(id, flag=nil)


### PR DESCRIPTION
Use relative path with require_rel instead of absolute path in order to fix require_all load error.

Steps to recreate error below:

#### 1. Create Gemfile

```
source "https://rubygems.org"
git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

gem 'jikan.rb'
```

#### 2. bundle install

```
$ bundle install --path vendor
```

#### 3. Create `app.rb`

```
require 'jikan.rb'
```

#### 4. Execute

```
$ bundle exec ruby app.rb 
Traceback (most recent call last):
        6: from app.rb:one:in `<main>'
        5: from app.rb:one:in `require'
        4: from /Users/USERNAME/my_fix_jikan_app/vendor/ruby/2.5.0/gems/jikan.rb-0.0.6/lib/jikan.rb:one:in `<top (required)>'
        3: from /Users/USERNAME/my_fix_jikan_app/vendor/ruby/2.5.0/gems/jikan.rb-0.0.6/lib/jikan.:one:1:in `require'
        2: from /Users/USERNAME/my_fix_jikan_app/vendor/ruby/2.5.0/gems/jikan.rb-0.0.6/lib/jikan/query.rb:two:in `<top (required)>'
        1: from /Users/USERNAME/my_fix_jikan_app/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:58:in `require_all'
/Users/USERNAME/my_fix_jikan_app/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:81:in `rescue in require_all': no such file to load -- lib/jikan/models (RequireAll::LoadError)
```